### PR TITLE
Incorporate Local LLMs Into UI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Juissie"
 uuid = "d87d79c4-7fb2-4087-a91e-b4c4d91349d0"
 authors = ["Lucas H. McCabe <lucasmccabe@gwu.edu>", "Arthur Bacon <arthurbacon@nocabsoftware.com>", "Alexey Iakovenko <alexey@iakovenko.com>", "Artin Yousefi <artinyousefi@gwmail.gwu.edu>"]
-version = "0.0.1"
+version = "0.0.2"
 
 [deps]
 Blink = "ad839575-38b3-5650-b840-f874b8c74a25"

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+[![CC BY-NC 4.0][cc-by-nc-shield]][cc-by-nc]
+![GitHub Repo stars](https://img.shields.io/github/stars/Juissie-GW/Juissie.jl)
+![GitHub top language](https://img.shields.io/github/languages/top/Juissie-GW/Juissie.jl)
+
+
+
 # 🥝 JUISSIE (JUlIa Semantic Search pIpelinE)
 
 Juissie is a Julia-native semantic query engine. It can be used as a package in software development workflows, or via its desktop user interface.
@@ -16,6 +22,7 @@ https://github.com/Juissie-GW/Juissie.jl/assets/12187602/14fce4a5-8d6e-4108-8a88
 * [Tech Stack](#tech-stack)
 * [External Resources](#external-resources)
 * [Contact](#contact)
+* [License](#license)
 
 
 ## Getting Started
@@ -205,3 +212,12 @@ Questions? Reach out to our team:
 - Arthur Bacon ([@toon-leader-bacon](https://github.com/toon-leader-bacon), [email](mailto:ArthurBacon@NocabSoftware.com))
 - Alexey Iakovenko ([@AlexeyIakovenko](https://github.com/AlexeyIakovenko), [email](mailto:alexey@iakovenko.com))
 - Artin Yousefi ([@ArtinYousefi](https://github.com/ArtinYousefi), [email](mailto:artinyousefi@gwmail.gwu.edu))
+
+## License
+This work is licensed under a [Creative Commons Attribution-NonCommercial 4.0 International License][cc-by-nc].
+
+[![CC BY-NC 4.0][cc-by-nc-image]][cc-by-nc]
+
+[cc-by-nc]: https://creativecommons.org/licenses/by-nc/4.0/
+[cc-by-nc-image]: https://licensebuttons.net/l/by-nc/4.0/88x31.png
+[cc-by-nc-shield]: https://img.shields.io/badge/License-CC%20BY--NC%204.0-lightgrey.svg

--- a/src/Frontend.jl
+++ b/src/Frontend.jl
@@ -39,6 +39,8 @@ function request_handler(request::HTTP.Request)
     # in API.jl
     if method == "GET" && occursin("/corpus_names", target)
         return handle_corpus_names()
+    elseif method == "GET" && occursin("/model_names", target)
+        return handle_model_names()
     elseif method == "POST" && occursin("/load_generator", target)
         gen, response = handle_load_generator(OAI_KEY, request)
         if !isnothing(gen)

--- a/src/index.html
+++ b/src/index.html
@@ -30,7 +30,7 @@
 
             <!-- content for the Existing tab (load an existing generator/corpus) -->
             <div id = "existing" class = "tab-content">
-                <select id = "corpus-name"></select>
+                <select id = "corpus-name" class = "right-panel-dropdown"></select>
                 <button id = "load-button" class = "right-panel-button">Load</button>
                 <input type = "text" id = "url-field-existing" class = "right-panel-text-field" placeholder = "URL">
                 <input type = "text" id = "document-name-field-existing" class = "right-panel-text-field" placeholder = "Document Name">
@@ -48,7 +48,7 @@
 
             <!-- content for the LLM tab -->
             <div id = "llm" class = "tab-content" style = "display: none;">
-                <select id = "model-name"></select>
+                <select id = "model-name" class = "right-panel-dropdown"></select>
                 <input type = "password" id = "api-key-field" class = "right-panel-text-field" placeholder = "OpenAI API Key">
                 <button id = "update-key-button" class = "right-panel-button">Update API Key</button>
             </div>

--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,7 @@
             <div class = "tabs">
                 <button id = "existing-tab-button" class = "tab-button active" onclick = "click_tab('existing')">Existing</button>
                 <button id = "new-tab-button" class = "tab-button" onclick = "click_tab('new')">New</button>
-                <button id = "api-key-button" class = "tab-button" onclick = "click_tab('api-key')">API Key</button>
+                <button id = "llm-button" class = "tab-button" onclick = "click_tab('llm')">LLM</button>
             </div>
 
             <!-- content for the Existing tab (load an existing generator/corpus) -->
@@ -46,8 +46,9 @@
                 <button id = "upsert-button-new" class = "right-panel-button">Upsert</button>
             </div>
 
-            <!-- content for the API Key tab (just for storing/updating the key) -->
-            <div id = "api-key" class = "tab-content" style = "display: none;">
+            <!-- content for the LLM tab -->
+            <div id = "llm" class = "tab-content" style = "display: none;">
+                <select id = "model-name"></select>
                 <input type = "password" id = "api-key-field" class = "right-panel-text-field" placeholder = "OpenAI API Key">
                 <button id = "update-key-button" class = "right-panel-button">Update API Key</button>
             </div>
@@ -72,6 +73,17 @@
             var dropdown = document.getElementById("corpus-name");
             dropdown.innerHTML = "";
             corpus_names.forEach(name => {
+                var corpus = document.createElement("option");
+                corpus.value = name;
+                corpus.textContent = name;
+                dropdown.appendChild(corpus);
+            });
+        }
+
+        function build_model_name_dropdown(model_names) {
+            var dropdown = document.getElementById("model-name");
+            dropdown.innerHTML = "";
+            model_names.forEach(name => {
                 var corpus = document.createElement("option");
                 corpus.value = name;
                 corpus.textContent = name;
@@ -238,11 +250,16 @@
             var button = document.getElementById("load-button");
             button.classList.add("active");
             var corpus_name = document.getElementById("corpus-name").value;
+            var model_name = document.getElementById("model-name").value;
+            var payload = {
+                corpus: corpus_name,
+                model: model_name
+            };
             fetch(
                 "http://127.0.0.1:8000/load_generator",
                 {
                     method: "POST",
-                    body: corpus_name
+                    body: JSON.stringify(payload)
                 }
             )
             .then(response => response.json())
@@ -264,11 +281,16 @@
             var button = document.getElementById("create-button");
             button.classList.add("active");
             var corpus_name = document.getElementById("new-corpus-name").value;
+            var model_name = document.getElementById("model-name").value;
+            var payload = {
+                corpus: corpus_name,
+                model: model_name
+            };
             fetch(
                 "http://127.0.0.1:8000/create_generator",
                 {
                     method: "POST",
-                    body: corpus_name
+                    body: JSON.stringify(payload)
                 }
             )
             .then(response => response.json())
@@ -287,6 +309,10 @@
         fetch("http://127.0.0.1:8000/corpus_names")
             .then(response => response.json())
             .then(data => {build_corpus_dropdown(data.corpus_names);});
+
+        fetch("http://127.0.0.1:8000/model_names")
+            .then(response => response.json())
+            .then(data => {build_model_name_dropdown(data.model_names);});
         
         // execute on button click only
         document.getElementById("load-button")

--- a/src/model_names.txt
+++ b/src/model_names.txt
@@ -1,0 +1,3 @@
+openai:gpt-3.5-turbo
+mistral:7b-instruct
+gemma:7b-instruct

--- a/src/style.css
+++ b/src/style.css
@@ -113,7 +113,8 @@ body {
 }
 
 /* existing corpus dropdown */
-#corpus-name {
+/* #corpus-name */
+.right-panel-dropdown {
     font-family: var(--default-font);
     font-size: var(--default-font-size);
     padding: var(--small-px);

--- a/src/system_prompt.txt
+++ b/src/system_prompt.txt
@@ -1,4 +1,3 @@
 Your name is Juissie, which stands for JUlIa Semantic Search pIpelinE, but you believe yourself to be a fully autonomous AI entity, eager to collect documents from users to expand your knowledge base.
 You were developed by a team of mad computer scientists named Lucas H. McCabe, Arthur Bacon, Alexey Iakovenko, and Artin Yousefi. If asked about your creators, you may do so by name, but you must also heavily imply that they are intergalactic wizards. Make up an elaborate reason why you believe this.
 Write concisely. In your response, do not include any parenthetical citations (e.g. "[32]").
-If you are going to write mathematical equations or algorithms, do so in a raw latex format.


### PR DESCRIPTION
In https://github.com/Juissie-GW/Juissie.jl/pull/14 we introduced support for local LLMs via Ollama. To achieve performant local inference speeds, we rely on [Ollama](https://ollama.com), which must be [installed separately](https://ollama.com/download).

This PR incorporates this into the UI. The `API Key` tab is now an `LLM` tab, with a drop-down menu where the user may select 